### PR TITLE
絵文字判定を追加 & カスタムHTML機能を削除

### DIFF
--- a/src/parse/nodes/inline.ts
+++ b/src/parse/nodes/inline.ts
@@ -133,6 +133,15 @@ class InlineKatex extends Node {
   }
 }
 
+class Emoji extends Node {
+  value: string;
+
+  constructor(text: string) {
+    super("emoji", "inline");
+    this.value = text;
+  }
+}
+
 export default {
   Text,
   Html,
@@ -146,4 +155,5 @@ export default {
   Video,
   Link,
   InlineKatex,
+  Emoji,
 };

--- a/src/parse/parser/block.ts
+++ b/src/parse/parser/block.ts
@@ -14,9 +14,7 @@ const KATEX_REGEX = /^[\$]{2}(.*)$/;
 const COLORBLOCK_REGEX = /^[\=]{3}(.*)|[\=]{3}(.*)\b[\l]+\b$/;
 const START_DETAILS_REGEX = /^\:\>(\b[\w_\.\/]+\b|[\u3040-\u309F\u30A0-\u30FF\u3400-\u9FFF])+$/;
 const END_DETAILS_REGEX = /^\:\>$/;
-const START_TAG_REGEX = /^\:\:\b[a-z]+\b|\:\:\b[a-z]+\b\.\b[a-z]+\b|\:\:\.\b[a-z]+\b$/;
-const END_TAG_REGEX = /^\:\:$/;
-const SLIDE_MODE_REGEX = /^\:use\sslide\:$/
+const SLIDE_MODE_REGEX = /^\|use\sslide\|$/
 const START_SLIDE_CENTER_REGEX = /^\:\-{3}\:(title|content)|\:\-{3}\:(title|content)\.\b[a-z]+\b$/;
 const START_SLIDE_LEFT_REGEX = /^\:\<\-{2}\:(title|content)|\:\<\-{2}\:(title|content)\.\b[a-z]+\b$/;
 const START_SLIDE_RIGHT_REGEX = /^\:\-{2}\>\:(title|content)|\:\-{2}\>\:(title|content)\.\b[a-z]+\b$/;
@@ -105,20 +103,6 @@ export const parser = (str: string) => {
     } else if (mode === MODE_DEFAULT && END_DETAILS_REGEX.test(line)) {
       parseStack(stack);
       ast.push(new nodes.EndDetails());
-      stack = "";
-    } else if (mode === MODE_DEFAULT && START_TAG_REGEX.test(line)) {
-      parseStack(stack);
-      const lineData = line.replace(/\:\:/, "").trim();
-      if (lineData) {
-        tagData = lineData.split(".");
-      } else {
-        tagData = ["span", ""];
-      }
-      ast.push(new nodes.StartTag(tagData[0] ?? "span", tagData[1]));
-      stack = "";
-    } else if (mode === MODE_DEFAULT && END_TAG_REGEX.test(line)) {
-      parseStack(stack);
-      ast.push(new nodes.EndTag(tagData ? tagData[0] : "span"));
       stack = "";
     } else if (CODE_REGEX.test(line)) {
       if (mode === MODE_CODE) {

--- a/src/parse/parser/inline.ts
+++ b/src/parse/parser/inline.ts
@@ -14,6 +14,7 @@ const MODE_LINK = 9;
 const MODE_INLINE_CODE = 10;
 const MODE_INLINE_KATEX = 11;
 const MODE_VIDEO = 12;
+const MODE_EMOJI = 13;
 
 type Prev = {
   value: string;
@@ -257,6 +258,16 @@ export default (text: string[] | string) => {
           continue;
         }
         break;
+      case ":":
+         if (mode === MODE_EMOJI) {
+          ast.push(new nodes.Emoji(stack));
+          mode = MODE_DEFAULT;
+        } else {
+          ast.push(new nodes.Text(stack));
+          mode = MODE_EMOJI;
+        }
+        stack = "";
+        continue;
       default:
         stack += char;
         break;


### PR DESCRIPTION
- カスタムHTML機能を削除
  - 直接HTMLが入力できるので、あまり意味がない機能になってるため
  - 後述の絵文字判定とコンフリクト起こす可能性があるため廃止
- 絵文字判定を追加
  - `:[英文字]:` で絵文字が入力できるようにする
  - インライン処理の判定に使用する 